### PR TITLE
Add multikino support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,18 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "sunday"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Quick repertoire
 
 Terminalowy scraper repertuarów kin napisany w Rust. Aktualnie obsługuje
-Cinema City i Helios, zapisuje konfigurację w `config.ini` obok binarki,
+Cinema City, Helios i Multikino, zapisuje konfigurację w `config.ini` obok binarki,
 cache'uje lokale w SQLite i wzbogaca repertuar o oceny oraz opisy z TMDB.
 
 ## Wymagania
@@ -58,6 +58,7 @@ Aby uruchomić kreator ponownie:
 ./target/release/quickrep repertoire bemowo 2024-12-06
 ./target/release/quickrep repertoire --chain cinema-city
 ./target/release/quickrep repertoire --chain helios
+./target/release/quickrep repertoire --chain multikino
 ./target/release/quickrep venues list
 ./target/release/quickrep venues update
 ./target/release/quickrep venues search manufaktura

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,7 +21,7 @@ use crate::domain::{
 use crate::error::{AppError, AppResult};
 use crate::logging::init_logging;
 use crate::output::{
-    StdoutTerminal, Terminal, cinema_venue_input_parser, date_input_parser,
+    StdoutTerminal, Terminal, cinema_venue_input_parser, date_input_parser, render_chains_table,
     render_repertoire_table, render_venues_table,
 };
 use crate::persistence::DatabaseManager;
@@ -142,6 +142,16 @@ pub async fn run_with_args(
         };
     }
 
+    if matches!(command, Commands::Chains) {
+        return match handle_chains_list(&dependencies.registry, terminal) {
+            Ok(()) => 0,
+            Err(error) => {
+                terminal.write_line(&error.to_string());
+                1
+            }
+        };
+    }
+
     let settings = match settings {
         Some(settings) => settings,
         None => match load_settings(&dependencies.paths) {
@@ -155,6 +165,7 @@ pub async fn run_with_args(
 
     let result = match command {
         Commands::Configure => unreachable!(),
+        Commands::Chains => unreachable!(),
         Commands::Repertoire { chain, venue_name, date } => {
             handle_repertoire(
                 CommandContext { settings: &settings, paths: &dependencies.paths },
@@ -209,6 +220,16 @@ pub async fn run_with_args(
             1
         }
     }
+}
+
+fn handle_chains_list(registry: &Registry, terminal: &mut dyn Terminal) -> AppResult<()> {
+    let chains = registry
+        .get_registered_chains()
+        .into_iter()
+        .map(|chain| (chain.display_name, chain.chain_id.as_str().to_string()))
+        .collect::<Vec<_>>();
+    terminal.write_line(&render_chains_table(&chains));
+    Ok(())
 }
 
 pub fn resolve_single_venue(found_venues: &[CinemaVenue]) -> AppResult<CinemaVenue> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -269,6 +269,24 @@ fn build_database_manager(paths: &AppPaths) -> AppResult<DatabaseManager> {
     DatabaseManager::new(paths.db_file())
 }
 
+async fn rehydrate_venues_database_if_missing(
+    settings: &Settings,
+    paths: &AppPaths,
+    registry: &Registry,
+) -> AppResult<()> {
+    if paths.db_file().exists() {
+        return Ok(());
+    }
+
+    let venues_by_chain =
+        fetch_registered_venues(settings, registry.get_registered_chains()).await?;
+    let payload = venues_by_chain
+        .into_iter()
+        .map(|(chain_id, venues)| (chain_id.as_str().to_string(), venues))
+        .collect::<HashMap<_, _>>();
+    build_database_manager(paths)?.replace_venues_batch(&payload)
+}
+
 async fn handle_repertoire(
     context: CommandContext<'_>,
     registry: &Registry,
@@ -281,6 +299,7 @@ async fn handle_repertoire(
     let registered_chain = resolve_chain(chain, context.settings, registry)?;
     let resolved_venue_name = resolve_venue_name(venue_name, &registered_chain, context.settings)?;
     let venue_name_parsed = cinema_venue_input_parser(&resolved_venue_name);
+    rehydrate_venues_database_if_missing(context.settings, context.paths, registry).await?;
     let db_manager = build_database_manager(context.paths)?;
     let found_venues =
         db_manager.find_venues_by_name(registered_chain.chain_id.as_str(), &venue_name_parsed)?;
@@ -316,6 +335,7 @@ async fn handle_venues_list(
     terminal: &mut dyn Terminal,
 ) -> AppResult<()> {
     let registered_chain = resolve_chain(chain, settings, registry)?;
+    rehydrate_venues_database_if_missing(settings, paths, registry).await?;
     let db_manager = build_database_manager(paths)?;
     let venues = db_manager.get_all_venues(registered_chain.chain_id.as_str())?;
     terminal.write_line(&render_venues_table(&venues, &registered_chain.display_name));
@@ -370,6 +390,7 @@ async fn handle_venues_search(
     terminal: &mut dyn Terminal,
 ) -> AppResult<()> {
     let registered_chain = resolve_chain(chain, settings, registry)?;
+    rehydrate_venues_database_if_missing(settings, paths, registry).await?;
     let db_manager = build_database_manager(paths)?;
     let venues = db_manager.find_venues_by_name(
         registered_chain.chain_id.as_str(),

--- a/src/cinema/cinema_city.rs
+++ b/src/cinema/cinema_city.rs
@@ -19,7 +19,7 @@ use crate::domain::{
     CinemaChainId, CinemaVenue, MovieLookupMetadata, MoviePlayDetails, MoviePlayTime, Repertoire,
 };
 use crate::error::{AppError, AppResult};
-use crate::logging::preview_for_log;
+use crate::logging::{preview_for_log, response_body_preview};
 use crate::retry::RetryPolicy;
 
 const REPERTOIRE_PAGE_READY_SELECTOR: &str = "h2.mr-sm";
@@ -750,7 +750,7 @@ impl CinemaCity {
             venue.venue_id
         );
         if status.is_client_error() || status.is_server_error() {
-            let body_preview = response_body_preview(response).await;
+            let body_preview = response_body_preview(response, MAX_LOG_BODY_PREVIEW_CHARS).await;
             debug!(
                 "Cinema City quickbook request failed url={quickbook_url} venue_id={} date={date} language={language} status={status} body_preview={body_preview}",
                 venue.venue_id
@@ -1059,12 +1059,4 @@ struct BookableMovieMetadata {
 struct QuickbookMovieEnrichment {
     lookup_metadata: MovieLookupMetadata,
     showtimes: HashSet<String>,
-}
-
-async fn response_body_preview(response: reqwest::Response) -> String {
-    match response.text().await {
-        Ok(body) if body.trim().is_empty() => "<empty>".to_string(),
-        Ok(body) => preview_for_log(&body, MAX_LOG_BODY_PREVIEW_CHARS),
-        Err(error) => format!("<unavailable: {error}>"),
-    }
 }

--- a/src/cinema/mod.rs
+++ b/src/cinema/mod.rs
@@ -2,4 +2,5 @@ pub mod browser;
 pub mod cinema_city;
 pub mod common;
 pub mod helios;
+pub mod multikino;
 pub mod registry;

--- a/src/cinema/multikino.rs
+++ b/src/cinema/multikino.rs
@@ -11,8 +11,8 @@ use crate::domain::{
     CinemaChainId, CinemaVenue, MovieLookupMetadata, MoviePlayDetails, MoviePlayTime, Repertoire,
 };
 use crate::error::{AppError, AppResult};
-use crate::logging::preview_for_log;
-use crate::retry::{RetryDirective, RetryPolicy, retry_with_backoff};
+use crate::logging::{preview_for_log, response_body_preview};
+use crate::retry::{RetryDirective, RetryPolicy, retry_after_delay, retry_with_backoff};
 
 pub const DEFAULT_MULTIKINO_BASE_URL: &str = "https://www.multikino.pl";
 
@@ -101,20 +101,33 @@ impl Multikino {
                     }
                 })?;
             let status = response.status();
+            let retry_after = if status == StatusCode::TOO_MANY_REQUESTS
+                || status == StatusCode::SERVICE_UNAVAILABLE
+            {
+                retry_after_delay(response.headers())
+            } else {
+                None
+            };
             if status.is_server_error()
                 || status == StatusCode::TOO_MANY_REQUESTS
                 || status == StatusCode::REQUEST_TIMEOUT
             {
-                let body_preview = response_body_preview(response).await;
+                let body_preview =
+                    response_body_preview(response, MAX_LOG_BODY_PREVIEW_CHARS).await;
                 debug!(
-                    "Multikino API retryable response operation={operation} url={url} status={status} body_preview={body_preview}",
+                    "Multikino API retryable response operation={operation} url={url} status={status} retry_after={retry_after:?} body_preview={body_preview}",
                 );
-                return Err(RetryDirective::retry(AppError::Http(format!(
+                let error = AppError::Http(format!(
                     "API Multikino zwróciło błąd podczas {operation}: status {status}"
-                ))));
+                ));
+                return Err(match retry_after {
+                    Some(delay) => RetryDirective::retry_after(error, delay),
+                    None => RetryDirective::retry(error),
+                });
             }
             if status.is_client_error() {
-                let body_preview = response_body_preview(response).await;
+                let body_preview =
+                    response_body_preview(response, MAX_LOG_BODY_PREVIEW_CHARS).await;
                 debug!(
                     "Multikino API non-retryable response operation={operation} url={url} status={status} body_preview={body_preview}",
                 );
@@ -159,8 +172,8 @@ impl Multikino {
 
         for group in groups {
             for cinema in group.cinemas {
-                if cinema.cinema_id.trim().is_empty() || !seen_ids.insert(cinema.cinema_id.clone())
-                {
+                let venue_id = cinema.cinema_id.trim();
+                if venue_id.is_empty() || !seen_ids.insert(venue_id.to_string()) {
                     continue;
                 }
 
@@ -172,7 +185,7 @@ impl Multikino {
 
                 venues.push(CinemaVenue {
                     chain_id: CinemaChainId::Multikino.as_str().to_string(),
-                    venue_id: cinema.cinema_id,
+                    venue_id: venue_id.to_string(),
                     venue_name,
                 });
             }
@@ -575,12 +588,4 @@ fn normalize_api_date(value: &str) -> Option<&str> {
 
 fn parse_release_year(value: &str) -> Option<i32> {
     value.get(0..4)?.parse::<i32>().ok()
-}
-
-async fn response_body_preview(response: reqwest::Response) -> String {
-    match response.text().await {
-        Ok(body) if body.trim().is_empty() => "<empty>".to_string(),
-        Ok(body) => preview_for_log(&body, MAX_LOG_BODY_PREVIEW_CHARS),
-        Err(error) => format!("<unavailable: {error}>"),
-    }
 }

--- a/src/cinema/multikino.rs
+++ b/src/cinema/multikino.rs
@@ -1,0 +1,586 @@
+use std::collections::HashSet;
+
+use async_trait::async_trait;
+use log::debug;
+use reqwest::{Client, StatusCode};
+use serde::Deserialize;
+
+use crate::cinema::common::{MISSING_DATA_LABEL, normalize_lookup_text};
+use crate::cinema::registry::CinemaChainClient;
+use crate::domain::{
+    CinemaChainId, CinemaVenue, MovieLookupMetadata, MoviePlayDetails, MoviePlayTime, Repertoire,
+};
+use crate::error::{AppError, AppResult};
+use crate::logging::preview_for_log;
+use crate::retry::{RetryDirective, RetryPolicy, retry_with_backoff};
+
+pub const DEFAULT_MULTIKINO_BASE_URL: &str = "https://www.multikino.pl";
+
+const DEFAULT_MULTIKINO_SHOWINGS_API_BASE_URL: &str =
+    "https://www.multikino.pl/api/microservice/showings";
+const MULTIKINO_ACCEPT_HEADER: &str = "application/json, text/plain, */*";
+const MULTIKINO_BROWSER_USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+     (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36";
+const MULTIKINO_FILMS_QUERY: &str =
+    "minEmbargoLevel=3&includesSession=true&includeSessionAttributes=true";
+const MULTIKINO_ATTRIBUTE_GROUPS_QUERY: &str = "minEmbargoLevel=2";
+const MAX_LOG_BODY_PREVIEW_CHARS: usize = 256;
+const FORMAT_GROUP_NAME: &str = "Rodzaj pokazu";
+const LANGUAGE_GROUP_NAME: &str = "Wersja językowa";
+const IGNORED_SESSION_ATTRIBUTES: [&str; 2] = ["Single Seat", "SUPERHIT"];
+
+#[derive(Clone)]
+pub struct Multikino {
+    base_url: String,
+    showings_api_base_url: String,
+    http_client: Client,
+    retry_policy: RetryPolicy,
+}
+
+impl Multikino {
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+            showings_api_base_url: DEFAULT_MULTIKINO_SHOWINGS_API_BASE_URL.to_string(),
+            http_client: Client::new(),
+            retry_policy: RetryPolicy::network_requests(),
+        }
+    }
+
+    pub fn with_retry_policy(mut self, retry_policy: RetryPolicy) -> Self {
+        self.retry_policy = retry_policy;
+        self
+    }
+
+    pub fn with_showings_api_base_url(mut self, showings_api_base_url: impl Into<String>) -> Self {
+        self.showings_api_base_url = showings_api_base_url.into();
+        self
+    }
+
+    fn venues_url(&self) -> String {
+        format!("{}/cinemas", self.showings_api_base_url.trim_end_matches('/'))
+    }
+
+    fn films_url(&self, venue_id: &str) -> String {
+        format!(
+            "{}/cinemas/{}/films?{MULTIKINO_FILMS_QUERY}",
+            self.showings_api_base_url.trim_end_matches('/'),
+            venue_id.trim(),
+        )
+    }
+
+    fn attribute_groups_url(&self, venue_id: &str) -> String {
+        format!(
+            "{}/attributes/showingAttributeGroups?cinemaId={}&{MULTIKINO_ATTRIBUTE_GROUPS_QUERY}",
+            self.showings_api_base_url.trim_end_matches('/'),
+            venue_id.trim(),
+        )
+    }
+
+    async fn fetch_api_result<T>(&self, url: &str, operation: &str) -> AppResult<T>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        retry_with_backoff(self.retry_policy, |attempt| async move {
+            debug!("Multikino API request attempt={attempt} operation={operation} url={url}");
+            let response = self
+                .http_client
+                .get(url)
+                .header(reqwest::header::USER_AGENT, MULTIKINO_BROWSER_USER_AGENT)
+                .header(reqwest::header::ACCEPT, MULTIKINO_ACCEPT_HEADER)
+                .send()
+                .await
+                .map_err(|error| {
+                    let app_error = AppError::Http(format!(
+                        "Nie udało się pobrać danych z API Multikino podczas {operation}: {error}"
+                    ));
+                    if error.is_timeout() || error.is_connect() {
+                        RetryDirective::retry(app_error)
+                    } else {
+                        RetryDirective::fail(app_error)
+                    }
+                })?;
+            let status = response.status();
+            if status.is_server_error()
+                || status == StatusCode::TOO_MANY_REQUESTS
+                || status == StatusCode::REQUEST_TIMEOUT
+            {
+                let body_preview = response_body_preview(response).await;
+                debug!(
+                    "Multikino API retryable response operation={operation} url={url} status={status} body_preview={body_preview}",
+                );
+                return Err(RetryDirective::retry(AppError::Http(format!(
+                    "API Multikino zwróciło błąd podczas {operation}: status {status}"
+                ))));
+            }
+            if status.is_client_error() {
+                let body_preview = response_body_preview(response).await;
+                debug!(
+                    "Multikino API non-retryable response operation={operation} url={url} status={status} body_preview={body_preview}",
+                );
+                return Err(RetryDirective::fail(AppError::Http(format!(
+                    "API Multikino zwróciło błąd podczas {operation}: status {status}"
+                ))));
+            }
+
+            let body = response.text().await.map_err(|error| {
+                let app_error = AppError::Http(format!(
+                    "Nie udało się odczytać odpowiedzi z API Multikino podczas {operation}: {error}"
+                ));
+                if error.is_timeout() {
+                    RetryDirective::retry(app_error)
+                } else {
+                    RetryDirective::fail(app_error)
+                }
+            })?;
+            debug!(
+                "Multikino API response received operation={operation} url={url} bytes={}",
+                body.len(),
+            );
+
+            let payload = serde_json::from_str::<MultikinoApiResponse<T>>(&body).map_err(|error| {
+                debug!(
+                    "Multikino API JSON parse failed operation={operation} url={url} error={error} body_preview={}",
+                    preview_for_log(&body, MAX_LOG_BODY_PREVIEW_CHARS),
+                );
+                RetryDirective::fail(AppError::Http(format!(
+                    "Nie udało się odczytać odpowiedzi z API Multikino podczas {operation}: {error}"
+                )))
+            })?;
+
+            payload.into_result(operation).map_err(RetryDirective::fail)
+        })
+        .await
+    }
+
+    fn parse_venues(groups: Vec<MultikinoCinemaGroup>) -> Vec<CinemaVenue> {
+        let mut seen_ids = HashSet::new();
+        let mut venues = Vec::new();
+
+        for group in groups {
+            for cinema in group.cinemas {
+                if cinema.cinema_id.trim().is_empty() || !seen_ids.insert(cinema.cinema_id.clone())
+                {
+                    continue;
+                }
+
+                let venue_name =
+                    cinema.full_name.as_deref().unwrap_or(&cinema.cinema_name).trim().to_string();
+                if venue_name.is_empty() {
+                    continue;
+                }
+
+                venues.push(CinemaVenue {
+                    chain_id: CinemaChainId::Multikino.as_str().to_string(),
+                    venue_id: cinema.cinema_id,
+                    venue_name,
+                });
+            }
+        }
+
+        venues.sort_by(|left, right| left.venue_name.cmp(&right.venue_name));
+        venues
+    }
+
+    fn extract_attribute_rules(groups: &[MultikinoShowingAttributeGroup]) -> AttributeRules {
+        let mut rules = AttributeRules::default();
+
+        for group in groups {
+            let target = match group.name.as_str() {
+                FORMAT_GROUP_NAME => Some(&mut rules.format_names),
+                LANGUAGE_GROUP_NAME => Some(&mut rules.language_names),
+                _ => None,
+            };
+            let Some(target) = target else {
+                continue;
+            };
+
+            for attribute in &group.showing_attributes {
+                let name = attribute.name.trim();
+                if !name.is_empty() {
+                    target.insert(name.to_string());
+                }
+            }
+        }
+
+        rules
+    }
+
+    fn parse_repertoire(
+        &self,
+        date: &str,
+        films: Vec<MultikinoFilm>,
+        attribute_rules: &AttributeRules,
+    ) -> Vec<Repertoire> {
+        films
+            .iter()
+            .filter_map(|film| self.parse_film_repertoire(date, film, attribute_rules))
+            .collect()
+    }
+
+    fn parse_film_repertoire(
+        &self,
+        date: &str,
+        film: &MultikinoFilm,
+        attribute_rules: &AttributeRules,
+    ) -> Option<Repertoire> {
+        let mut sessions_for_date = film
+            .showing_groups
+            .iter()
+            .filter(|group| normalize_api_date(&group.date).is_some_and(|value| value == date))
+            .flat_map(|group| group.sessions.iter())
+            .collect::<Vec<_>>();
+        if sessions_for_date.is_empty() {
+            return None;
+        }
+        sessions_for_date.sort_by(|left, right| left.start_time.cmp(&right.start_time));
+
+        let mut play_details = Vec::<MoviePlayDetails>::new();
+        for session in sessions_for_date {
+            let Some(play_time_value) = extract_showtime_value(&session.start_time) else {
+                continue;
+            };
+            let format = select_session_format(&session.attributes, attribute_rules);
+            let play_language = select_session_language(&session.attributes, attribute_rules);
+            let play_time = MoviePlayTime {
+                value: play_time_value,
+                url: booking_url_for_session(&self.base_url, session),
+            };
+
+            if let Some(existing) = play_details
+                .iter_mut()
+                .find(|detail| detail.format == format && detail.play_language == play_language)
+            {
+                existing.play_times.push(play_time);
+            } else {
+                play_details.push(MoviePlayDetails {
+                    format,
+                    play_language,
+                    play_times: vec![play_time],
+                });
+            }
+        }
+
+        if play_details.is_empty() {
+            return None;
+        }
+
+        Some(Repertoire {
+            title: film.film_title.clone(),
+            genres: join_or_missing(&film.genres),
+            play_length: render_play_length(film.running_time, film.is_duration_unknown),
+            original_language: MISSING_DATA_LABEL.to_string(),
+            play_details,
+            lookup_metadata: build_lookup_metadata(&self.base_url, film),
+        })
+    }
+}
+
+#[async_trait]
+impl CinemaChainClient for Multikino {
+    async fn fetch_repertoire(
+        &self,
+        date: &str,
+        venue: &CinemaVenue,
+    ) -> AppResult<Vec<Repertoire>> {
+        let films_url = self.films_url(&venue.venue_id);
+        debug!(
+            "Multikino repertoire fetch starting url={films_url} venue_id={} venue_name={:?} date={date}",
+            venue.venue_id, venue.venue_name,
+        );
+        let films = self
+            .fetch_api_result::<Vec<MultikinoFilm>>(&films_url, "pobierania repertuaru")
+            .await?;
+        let attribute_rules = match self
+            .fetch_api_result::<Vec<MultikinoShowingAttributeGroup>>(
+                &self.attribute_groups_url(&venue.venue_id),
+                "pobierania atrybutów repertuaru",
+            )
+            .await
+        {
+            Ok(groups) => Self::extract_attribute_rules(&groups),
+            Err(error) => {
+                debug!(
+                    "Multikino attribute groups lookup failed venue_id={} date={date} error={error}",
+                    venue.venue_id,
+                );
+                AttributeRules::default()
+            }
+        };
+
+        Ok(self.parse_repertoire(date, films, &attribute_rules))
+    }
+
+    async fn fetch_venues(&self) -> AppResult<Vec<CinemaVenue>> {
+        let url = self.venues_url();
+        debug!("Multikino venues fetch starting url={url}");
+        let groups = self
+            .fetch_api_result::<Vec<MultikinoCinemaGroup>>(&url, "pobierania listy lokali")
+            .await?;
+        Ok(Self::parse_venues(groups))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct MultikinoApiResponse<T> {
+    result: T,
+    #[serde(rename = "responseCode")]
+    response_code: i32,
+    #[serde(rename = "errorMessage")]
+    error_message: Option<String>,
+}
+
+impl<T> MultikinoApiResponse<T> {
+    fn into_result(self, operation: &str) -> AppResult<T> {
+        if self.response_code == 0 {
+            Ok(self.result)
+        } else {
+            Err(AppError::Http(format!(
+                "API Multikino zwróciło błąd podczas {operation}: {}",
+                self.error_message.unwrap_or_else(|| format!("kod {}", self.response_code))
+            )))
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct MultikinoCinemaGroup {
+    cinemas: Vec<MultikinoCinema>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MultikinoCinema {
+    #[serde(rename = "cinemaId")]
+    cinema_id: String,
+    #[serde(rename = "cinemaName")]
+    cinema_name: String,
+    #[serde(rename = "fullName")]
+    full_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MultikinoFilm {
+    #[serde(rename = "filmId")]
+    film_id: String,
+    #[serde(rename = "filmUrl")]
+    film_url: Option<String>,
+    #[serde(rename = "filmTitle")]
+    film_title: String,
+    #[serde(rename = "originalTitle")]
+    original_title: Option<String>,
+    #[serde(rename = "releaseDate")]
+    release_date: Option<String>,
+    #[serde(rename = "runningTime", default)]
+    running_time: u16,
+    #[serde(rename = "isDurationUnknown", default)]
+    is_duration_unknown: bool,
+    #[serde(default)]
+    genres: Vec<String>,
+    #[serde(rename = "showingGroups", default)]
+    showing_groups: Vec<MultikinoShowingGroup>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MultikinoShowingGroup {
+    date: String,
+    #[serde(default)]
+    sessions: Vec<MultikinoSession>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MultikinoSession {
+    #[serde(rename = "bookingUrl")]
+    booking_url: Option<String>,
+    #[serde(rename = "startTime")]
+    start_time: String,
+    #[serde(rename = "isSoldOut", default)]
+    is_sold_out: bool,
+    #[serde(rename = "isBookingAvailable", default)]
+    is_booking_available: bool,
+    #[serde(default)]
+    attributes: Vec<MultikinoShowingAttribute>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MultikinoShowingAttributeGroup {
+    name: String,
+    #[serde(rename = "showingAttributes", default)]
+    showing_attributes: Vec<MultikinoShowingAttribute>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MultikinoShowingAttribute {
+    name: String,
+    #[serde(rename = "attributeType")]
+    attribute_type: String,
+}
+
+#[derive(Default)]
+struct AttributeRules {
+    format_names: HashSet<String>,
+    language_names: HashSet<String>,
+}
+
+fn render_play_length(running_time: u16, is_duration_unknown: bool) -> String {
+    if is_duration_unknown || running_time == 0 {
+        MISSING_DATA_LABEL.to_string()
+    } else {
+        format!("{running_time} min")
+    }
+}
+
+fn build_lookup_metadata(base_url: &str, film: &MultikinoFilm) -> MovieLookupMetadata {
+    let alternate_titles =
+        collect_alternate_titles(&film.film_title, film.original_title.as_deref());
+    let premiere_date =
+        film.release_date.as_deref().and_then(normalize_api_date).map(str::to_string);
+
+    MovieLookupMetadata {
+        chain_movie_id: Some(film.film_id.clone()),
+        movie_page_url: film.film_url.as_deref().and_then(|url| build_absolute_url(base_url, url)),
+        alternate_titles,
+        runtime_minutes: if film.running_time == 0 || film.is_duration_unknown {
+            None
+        } else {
+            Some(film.running_time)
+        },
+        original_language_code: None,
+        genre_tags: normalize_genre_tags(&film.genres),
+        production_year: premiere_date.as_deref().and_then(parse_release_year),
+        polish_premiere_date: premiere_date,
+    }
+}
+
+fn collect_alternate_titles(title: &str, original_title: Option<&str>) -> Vec<String> {
+    let Some(original_title) = original_title.map(str::trim).filter(|value| !value.is_empty())
+    else {
+        return Vec::new();
+    };
+    if normalize_lookup_text(title) == normalize_lookup_text(original_title) {
+        Vec::new()
+    } else {
+        vec![original_title.to_string()]
+    }
+}
+
+fn normalize_genre_tags(genres: &[String]) -> Vec<String> {
+    let mut tags = Vec::new();
+    for genre in genres {
+        let normalized = normalize_lookup_text(genre);
+        if !normalized.is_empty() && !tags.contains(&normalized) {
+            tags.push(normalized);
+        }
+    }
+    tags
+}
+
+fn join_or_missing(values: &[String]) -> String {
+    let joined = values
+        .iter()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>()
+        .join(", ");
+    if joined.is_empty() { MISSING_DATA_LABEL.to_string() } else { joined }
+}
+
+fn select_session_format(
+    attributes: &[MultikinoShowingAttribute],
+    attribute_rules: &AttributeRules,
+) -> String {
+    let values = collect_attribute_values(
+        attributes,
+        "Session",
+        &attribute_rules.format_names,
+        &IGNORED_SESSION_ATTRIBUTES,
+    );
+    if values.is_empty() { MISSING_DATA_LABEL.to_string() } else { values.join(" ") }
+}
+
+fn select_session_language(
+    attributes: &[MultikinoShowingAttribute],
+    attribute_rules: &AttributeRules,
+) -> String {
+    let values =
+        collect_attribute_values(attributes, "Language", &attribute_rules.language_names, &[]);
+    if values.is_empty() { MISSING_DATA_LABEL.to_string() } else { values.join(" ") }
+}
+
+fn collect_attribute_values<'a>(
+    attributes: &'a [MultikinoShowingAttribute],
+    attribute_type: &str,
+    allowed_names: &HashSet<String>,
+    ignored_names: &[&str],
+) -> Vec<&'a str> {
+    let mut values =
+        collect_attribute_values_inner(attributes, attribute_type, allowed_names, ignored_names);
+    if values.is_empty() && !allowed_names.is_empty() {
+        values = collect_attribute_values_inner(
+            attributes,
+            attribute_type,
+            &HashSet::new(),
+            ignored_names,
+        );
+    }
+    values
+}
+
+fn collect_attribute_values_inner<'a>(
+    attributes: &'a [MultikinoShowingAttribute],
+    attribute_type: &str,
+    allowed_names: &HashSet<String>,
+    ignored_names: &[&str],
+) -> Vec<&'a str> {
+    let mut values = Vec::new();
+    for attribute in attributes {
+        let name = attribute.name.trim();
+        if attribute.attribute_type != attribute_type
+            || name.is_empty()
+            || ignored_names.contains(&name)
+            || (!allowed_names.is_empty() && !allowed_names.contains(name))
+            || values.contains(&name)
+        {
+            continue;
+        }
+        values.push(name);
+    }
+    values
+}
+
+fn booking_url_for_session(base_url: &str, session: &MultikinoSession) -> Option<String> {
+    if session.is_sold_out || !session.is_booking_available {
+        return None;
+    }
+    session.booking_url.as_deref().and_then(|value| build_absolute_url(base_url, value))
+}
+
+fn build_absolute_url(base_url: &str, value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        Some(trimmed.to_string())
+    } else {
+        Some(format!("{}/{}", base_url.trim_end_matches('/'), trimmed.trim_start_matches('/'),))
+    }
+}
+
+fn extract_showtime_value(start_time: &str) -> Option<String> {
+    start_time.split('T').nth(1).and_then(|value| value.get(0..5)).map(str::to_string)
+}
+
+fn normalize_api_date(value: &str) -> Option<&str> {
+    value.get(0..10)
+}
+
+fn parse_release_year(value: &str) -> Option<i32> {
+    value.get(0..4)?.parse::<i32>().ok()
+}
+
+async fn response_body_preview(response: reqwest::Response) -> String {
+    match response.text().await {
+        Ok(body) if body.trim().is_empty() => "<empty>".to_string(),
+        Ok(body) => preview_for_log(&body, MAX_LOG_BODY_PREVIEW_CHARS),
+        Err(error) => format!("<unavailable: {error}>"),
+    }
+}

--- a/src/cinema/registry.rs
+++ b/src/cinema/registry.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use crate::cinema::browser::HtmlRenderer;
 use crate::cinema::cinema_city::CinemaCity;
 use crate::cinema::helios::{DEFAULT_HELIOS_BASE_URL, DEFAULT_HELIOS_VENUES_URL, Helios};
+use crate::cinema::multikino::{DEFAULT_MULTIKINO_BASE_URL, Multikino};
 use crate::config::{
     DEFAULT_CINEMA_CITY_REPERTOIRE_URL, DEFAULT_CINEMA_CITY_VENUES_LIST_URL, Settings,
 };
@@ -51,6 +52,9 @@ impl Registry {
                 helios_renderer.clone(),
             )) as Box<dyn CinemaChainClient>
         });
+        let multikino_factory = Arc::new(move |_settings: &Settings| {
+            Box::new(Multikino::new(DEFAULT_MULTIKINO_BASE_URL)) as Box<dyn CinemaChainClient>
+        });
 
         Self::from_chains(vec![
             RegisteredCinemaChain {
@@ -62,6 +66,11 @@ impl Registry {
                 chain_id: CinemaChainId::Helios,
                 display_name: "Helios".to_string(),
                 client_factory: helios_factory,
+            },
+            RegisteredCinemaChain {
+                chain_id: CinemaChainId::Multikino,
+                display_name: "Multikino".to_string(),
+                client_factory: multikino_factory,
             },
         ])
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,6 +46,12 @@ pub enum Commands {
     )]
     Configure,
     #[command(
+        about = "Wyświetla obsługiwane sieci kin",
+        long_about = None,
+        help_template = POLISH_HELP_TEMPLATE
+    )]
+    Chains,
+    #[command(
         about = "Wyświetla repertuar dla wybranego lokalu",
         long_about = None,
         help_template = POLISH_HELP_TEMPLATE,

--- a/src/config.rs
+++ b/src/config.rs
@@ -196,7 +196,7 @@ pub fn should_skip_bootstrap_for_argv(argv: &[String]) -> bool {
 pub fn should_defer_bootstrap_to_command(argv: &[String]) -> bool {
     argv.iter()
         .find(|argument| !argument.starts_with('-'))
-        .is_some_and(|argument| argument == "configure")
+        .is_some_and(|argument| argument == "configure" || argument == "chains")
 }
 
 pub async fn ensure_settings_for_argv(

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -6,10 +6,11 @@ use crate::error::{AppError, AppResult};
 pub enum CinemaChainId {
     CinemaCity,
     Helios,
+    Multikino,
 }
 
 impl CinemaChainId {
-    pub const ALL: [Self; 2] = [Self::CinemaCity, Self::Helios];
+    pub const ALL: [Self; 3] = [Self::CinemaCity, Self::Helios, Self::Multikino];
 
     pub fn all() -> &'static [Self] {
         &Self::ALL
@@ -20,6 +21,7 @@ impl CinemaChainId {
         match normalized.as_str() {
             "cinema-city" => Ok(Self::CinemaCity),
             "helios" => Ok(Self::Helios),
+            "multikino" => Ok(Self::Multikino),
             _ => Err(AppError::UnsupportedCinemaChain {
                 invalid_chain: value.to_string(),
                 supported_chains: Self::supported_values().join(", "),
@@ -31,6 +33,7 @@ impl CinemaChainId {
         match self {
             Self::CinemaCity => "cinema-city",
             Self::Helios => "helios",
+            Self::Multikino => "multikino",
         }
     }
 
@@ -38,6 +41,7 @@ impl CinemaChainId {
         match self {
             Self::CinemaCity => "cinema_city",
             Self::Helios => "helios",
+            Self::Multikino => "multikino",
         }
     }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -44,6 +44,14 @@ pub fn redact_secret(secret: &str) -> String {
     format!("{prefix}***{suffix} (len={total_chars})")
 }
 
+pub async fn response_body_preview(response: reqwest::Response, max_chars: usize) -> String {
+    match response.text().await {
+        Ok(body) if body.trim().is_empty() => "<empty>".to_string(),
+        Ok(body) => preview_for_log(&body, max_chars),
+        Err(error) => format!("<unavailable: {error}>"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/output.rs
+++ b/src/output.rs
@@ -110,6 +110,24 @@ pub fn render_venues_table(venues: &[CinemaVenue], chain_display_name: &str) -> 
     format!("Znalezione lokale sieci {chain_display_name}\n{table}")
 }
 
+pub fn render_chains_table(chains: &[(String, String)]) -> String {
+    if chains.is_empty() {
+        return "Brak obsługiwanych sieci kin.".to_string();
+    }
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_header(vec!["Nazwa sieci", "ID sieci"]);
+
+    for (display_name, chain_id) in chains {
+        table.add_row(vec![Cell::new(display_name), Cell::new(chain_id)]);
+    }
+
+    format!("Obsługiwane sieci kin\n{table}")
+}
+
 pub fn render_repertoire_table(
     repertoire: &[Repertoire],
     table_metadata: &RepertoireCliTableMetadata,

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,7 +1,9 @@
 use std::future::Future;
 use std::time::Duration;
 
+use chrono::Utc;
 use log::debug;
+use reqwest::header::{HeaderMap, RETRY_AFTER};
 use tokio::time::sleep;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -49,6 +51,34 @@ impl<E> RetryDirective<E> {
     pub fn retry_after(error: E, delay: Duration) -> Self {
         Self::RetryAfter { error, delay }
     }
+}
+
+pub fn retry_after_delay(headers: &HeaderMap) -> Option<Duration> {
+    let raw_value = headers.get(RETRY_AFTER)?;
+    let raw_value = match raw_value.to_str() {
+        Ok(raw_value) => raw_value,
+        Err(error) => {
+            debug!("Response included an invalid Retry-After header: {error}");
+            return None;
+        }
+    };
+
+    if let Ok(delay_seconds) = raw_value.parse::<u64>() {
+        return Some(Duration::from_secs(delay_seconds));
+    }
+
+    if let Ok(retry_after) = chrono::DateTime::parse_from_rfc2822(raw_value) {
+        return Some(
+            retry_after
+                .with_timezone(&Utc)
+                .signed_duration_since(Utc::now())
+                .to_std()
+                .unwrap_or(Duration::ZERO),
+        );
+    }
+
+    debug!("Response included an unparseable Retry-After header value={raw_value:?}");
+    None
 }
 
 pub async fn retry_with_backoff<T, E, O, Fut>(policy: RetryPolicy, mut operation: O) -> Result<T, E>
@@ -105,6 +135,22 @@ mod tests {
         assert_eq!(policy.delay_for_retry(2), Duration::from_millis(200));
         assert_eq!(policy.delay_for_retry(3), Duration::from_millis(250));
         assert_eq!(policy.delay_for_retry(4), Duration::from_millis(250));
+    }
+
+    #[test]
+    fn retry_after_delay_parses_delay_seconds() {
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, "12".parse().unwrap());
+
+        assert_eq!(retry_after_delay(&headers), Some(Duration::from_secs(12)));
+    }
+
+    #[test]
+    fn retry_after_delay_ignores_invalid_values() {
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, "not-a-delay".parse().unwrap());
+
+        assert_eq!(retry_after_delay(&headers), None);
     }
 
     #[tokio::test]

--- a/src/tmdb.rs
+++ b/src/tmdb.rs
@@ -1458,7 +1458,7 @@ fn render_details_from_detailed(movie: &TmdbMovieDetailsResponse) -> TmdbMovieDe
 fn render_rating(vote_average: Option<f64>, vote_count: Option<u32>) -> String {
     match (vote_average, vote_count) {
         (Some(vote_average), Some(vote_count)) => {
-            format!("{vote_average}/10\n(głosy: {vote_count})")
+            format!("{vote_average:.1}/10\n(głosy: {vote_count})")
         }
         _ => String::new(),
     }
@@ -1566,4 +1566,14 @@ fn has_runtime_conflict(expected_runtime: Option<u16>, candidate_runtime: Option
         return false;
     };
     expected_runtime.abs_diff(candidate_runtime) > MAX_ACCEPTABLE_RUNTIME_CONFLICT_MINUTES
+}
+
+#[cfg(test)]
+mod tests {
+    use super::render_rating;
+
+    #[test]
+    fn render_rating_rounds_to_one_decimal_place() {
+        assert_eq!(render_rating(Some(6.717), Some(184)), "6.7/10\n(głosy: 184)");
+    }
 }

--- a/src/tmdb.rs
+++ b/src/tmdb.rs
@@ -1,13 +1,11 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
-use std::time::Duration;
 
 use async_trait::async_trait;
-use chrono::{Datelike, NaiveDate, Utc};
+use chrono::{Datelike, NaiveDate};
 use futures::{StreamExt, stream};
 use log::debug;
 use regex::Regex;
-use reqwest::header::{HeaderMap, RETRY_AFTER};
 use reqwest::{Client, StatusCode};
 use serde::Deserialize;
 
@@ -16,8 +14,8 @@ use crate::domain::{
     MovieLookupMetadata, MoviePageFallbackDetails, TmdbLookupMovie, TmdbMovieDetails,
 };
 use crate::error::{AppError, AppResult};
-use crate::logging::{preview_for_log, redact_secret};
-use crate::retry::{RetryDirective, RetryPolicy, retry_with_backoff};
+use crate::logging::{preview_for_log, redact_secret, response_body_preview};
+use crate::retry::{RetryDirective, RetryPolicy, retry_after_delay, retry_with_backoff};
 
 const REQUEST_TIMEOUT_SECONDS: u64 = 30;
 const MAX_LOG_BODY_PREVIEW_CHARS: usize = 256;
@@ -149,7 +147,7 @@ impl ReqwestTmdbClient {
                     debug!(
                         "TMDB authentication rejected credentials attempt={attempt} url={} body_preview={}",
                         self.auth_url,
-                        response_body_preview(response).await,
+                        response_body_preview(response, MAX_LOG_BODY_PREVIEW_CHARS).await,
                     );
                     return Ok(false);
                 }
@@ -159,7 +157,7 @@ impl ReqwestTmdbClient {
                     debug!(
                         "TMDB authentication received retryable status attempt={attempt} url={} status={status} body_preview={}",
                         self.auth_url,
-                        response_body_preview(response).await,
+                        response_body_preview(response, MAX_LOG_BODY_PREVIEW_CHARS).await,
                     );
                     return Err(match retry_after {
                         Some(delay) => RetryDirective::retry_after(error, delay),
@@ -170,7 +168,7 @@ impl ReqwestTmdbClient {
                 debug!(
                     "TMDB authentication returned unexpected non-success status attempt={attempt} url={} status={status} body_preview={}",
                     self.auth_url,
-                    response_body_preview(response).await,
+                    response_body_preview(response, MAX_LOG_BODY_PREVIEW_CHARS).await,
                 );
                 Ok(false)
             }
@@ -231,7 +229,7 @@ impl ReqwestTmdbClient {
                         "TMDB movie search authorization failed attempt={attempt} query={:?} url={} body_preview={}",
                         search_request.query,
                         self.search_url,
-                        response_body_preview(response).await,
+                        response_body_preview(response, MAX_LOG_BODY_PREVIEW_CHARS).await,
                     );
                     return Err(RetryDirective::fail(tmdb_status_error(status)));
                 }
@@ -242,7 +240,7 @@ impl ReqwestTmdbClient {
                         "TMDB movie search received retryable status attempt={attempt} query={:?} url={} status={status} body_preview={}",
                         search_request.query,
                         self.search_url,
-                        response_body_preview(response).await,
+                        response_body_preview(response, MAX_LOG_BODY_PREVIEW_CHARS).await,
                     );
                     return Err(match retry_after {
                         Some(delay) => RetryDirective::retry_after(error, delay),
@@ -255,7 +253,7 @@ impl ReqwestTmdbClient {
                         "TMDB movie search failed with non-retryable status attempt={attempt} query={:?} url={} status={status} body_preview={}",
                         search_request.query,
                         self.search_url,
-                        response_body_preview(response).await,
+                        response_body_preview(response, MAX_LOG_BODY_PREVIEW_CHARS).await,
                     );
                     return Err(RetryDirective::fail(tmdb_status_error(status)));
                 }
@@ -342,7 +340,7 @@ impl ReqwestTmdbClient {
                         "TMDB movie details authorization failed attempt={attempt} movie_id={} url={} body_preview={}",
                         movie_id,
                         details_url,
-                        response_body_preview(response).await,
+                        response_body_preview(response, MAX_LOG_BODY_PREVIEW_CHARS).await,
                     );
                     return Err(RetryDirective::fail(tmdb_status_error(status)));
                 }
@@ -353,7 +351,7 @@ impl ReqwestTmdbClient {
                         "TMDB movie details received retryable status attempt={attempt} movie_id={} url={} status={status} body_preview={}",
                         movie_id,
                         details_url,
-                        response_body_preview(response).await,
+                        response_body_preview(response, MAX_LOG_BODY_PREVIEW_CHARS).await,
                     );
                     return Err(match retry_after {
                         Some(delay) => RetryDirective::retry_after(error, delay),
@@ -366,7 +364,7 @@ impl ReqwestTmdbClient {
                         "TMDB movie details failed with non-retryable status attempt={attempt} movie_id={} url={} status={status} body_preview={}",
                         movie_id,
                         details_url,
-                        response_body_preview(response).await,
+                        response_body_preview(response, MAX_LOG_BODY_PREVIEW_CHARS).await,
                     );
                     return Err(RetryDirective::fail(tmdb_status_error(status)));
                 }
@@ -435,7 +433,7 @@ impl ReqwestTmdbClient {
             if status.is_client_error() || status.is_server_error() {
                 debug!(
                     "Movie page fallback request failed attempt={attempt} url={movie_page_url} status={status} body_preview={}",
-                    response_body_preview(response).await,
+                    response_body_preview(response, MAX_LOG_BODY_PREVIEW_CHARS).await,
                 );
                 return Err(RetryDirective::fail(AppError::Http(format!(
                     "Żądanie strony filmu zakończyło się błędem: status {status}."
@@ -923,34 +921,6 @@ fn classify_tmdb_response_read_error(
         error.is_body(),
     );
     if retryable { RetryDirective::retry(app_error) } else { RetryDirective::fail(app_error) }
-}
-
-fn retry_after_delay(headers: &HeaderMap) -> Option<Duration> {
-    let raw_value = headers.get(RETRY_AFTER)?;
-    let raw_value = match raw_value.to_str() {
-        Ok(raw_value) => raw_value,
-        Err(error) => {
-            debug!("TMDB response included an invalid Retry-After header: {error}");
-            return None;
-        }
-    };
-
-    if let Ok(delay_seconds) = raw_value.parse::<u64>() {
-        return Some(Duration::from_secs(delay_seconds));
-    }
-
-    if let Ok(retry_after) = chrono::DateTime::parse_from_rfc2822(raw_value) {
-        return Some(
-            retry_after
-                .with_timezone(&Utc)
-                .signed_duration_since(Utc::now())
-                .to_std()
-                .unwrap_or(Duration::ZERO),
-        );
-    }
-
-    debug!("TMDB response included an unparseable Retry-After header value={raw_value:?}");
-    None
 }
 
 fn rank_search_candidates(
@@ -1596,12 +1566,4 @@ fn has_runtime_conflict(expected_runtime: Option<u16>, candidate_runtime: Option
         return false;
     };
     expected_runtime.abs_diff(candidate_runtime) > MAX_ACCEPTABLE_RUNTIME_CONFLICT_MINUTES
-}
-
-async fn response_body_preview(response: reqwest::Response) -> String {
-    match response.text().await {
-        Ok(body) if body.trim().is_empty() => "<empty>".to_string(),
-        Ok(body) => preview_for_log(&body, MAX_LOG_BODY_PREVIEW_CHARS),
-        Err(error) => format!("<unavailable: {error}>"),
-    }
 }

--- a/tests/app_test.rs
+++ b/tests/app_test.rs
@@ -248,6 +248,84 @@ async fn repertoire_command_supports_helios_chain() {
 }
 
 #[tokio::test]
+async fn repertoire_command_supports_multikino_chain() {
+    let temp_dir = tempdir().unwrap();
+    let dependencies = dependencies_with_chains(
+        temp_dir.path(),
+        FakePrompt::new(Vec::new(), Vec::new()),
+        vec![
+            registered_chain(
+                CinemaChainId::CinemaCity,
+                "Cinema City",
+                FakeCinemaClient::new(Vec::new(), Vec::new()),
+            ),
+            registered_chain(
+                CinemaChainId::Multikino,
+                "Multikino",
+                FakeCinemaClient::new(
+                    vec![Repertoire {
+                        title: "Multikino Movie".to_string(),
+                        genres: "science fiction".to_string(),
+                        play_length: "157 min".to_string(),
+                        original_language: "Brak danych".to_string(),
+                        play_details: vec![MoviePlayDetails {
+                            format: "2D".to_string(),
+                            play_language: "NAPISY".to_string(),
+                            play_times: vec![MoviePlayTime {
+                                value: "19:30".to_string(),
+                                url: Some(
+                                    "https://www.multikino.pl/rezerwacja-biletow/podsumowanie/0034/HO00002328/64812"
+                                        .to_string(),
+                                ),
+                            }],
+                        }],
+                        lookup_metadata: MovieLookupMetadata::default(),
+                    }],
+                    Vec::new(),
+                ),
+            ),
+        ],
+        FakeTmdbService { result: Default::default(), error: None },
+    );
+    let mut configured_settings = settings();
+    configured_settings
+        .user_preferences
+        .default_venues
+        .set(CinemaChainId::Multikino, Some("Warszawa Złote Tarasy".to_string()));
+    write_settings(&configured_settings, &dependencies.paths).unwrap();
+    DatabaseManager::new(dependencies.paths.db_file())
+        .unwrap()
+        .replace_venues(
+            "multikino",
+            &[CinemaVenue {
+                chain_id: "multikino".to_string(),
+                venue_name: "Warszawa Złote Tarasy".to_string(),
+                venue_id: "0034".to_string(),
+            }],
+        )
+        .unwrap();
+    let mut terminal = BufferTerminal::default();
+
+    let exit_code = run_with_args(
+        vec![
+            "quickrep".to_string(),
+            "repertoire".to_string(),
+            "--chain".to_string(),
+            "multikino".to_string(),
+        ],
+        &dependencies,
+        &mut terminal,
+    )
+    .await;
+
+    let output = terminal.into_string();
+    assert_eq!(exit_code, 0);
+    assert!(output.contains("Repertuar dla Multikino"));
+    assert!(output.contains("Warszawa Złote Tarasy"));
+    assert!(output.contains("Multikino Movie"));
+}
+
+#[tokio::test]
 async fn venues_update_without_chain_refreshes_all_supported_chains_concurrently() {
     let temp_dir = tempdir().unwrap();
     let tracker = Arc::new(ConcurrencyTracker::default());

--- a/tests/app_test.rs
+++ b/tests/app_test.rs
@@ -689,6 +689,108 @@ async fn repertoire_command_bootstraps_configuration_before_running() {
 }
 
 #[tokio::test]
+async fn repertoire_command_rehydrates_missing_database_before_running() {
+    let temp_dir = tempdir().unwrap();
+    let dependencies = dependencies_with_chains(
+        temp_dir.path(),
+        FakePrompt::new(Vec::new(), Vec::new()),
+        vec![
+            registered_chain(
+                CinemaChainId::CinemaCity,
+                "Cinema City",
+                FakeCinemaClient::new(
+                    vec![Repertoire {
+                        title: "Test Movie".to_string(),
+                        genres: "Thriller".to_string(),
+                        play_length: "120 min".to_string(),
+                        original_language: "EN".to_string(),
+                        play_details: vec![MoviePlayDetails {
+                            format: "2D".to_string(),
+                            play_language: "NAP: PL".to_string(),
+                            play_times: vec![
+                                MoviePlayTime { value: "10:00".to_string(), url: None },
+                                MoviePlayTime { value: "12:30".to_string(), url: None },
+                            ],
+                        }],
+                        lookup_metadata: MovieLookupMetadata::default(),
+                    }],
+                    vec![
+                        CinemaVenue {
+                            chain_id: "cinema-city".to_string(),
+                            venue_name: "Warszawa - Janki".to_string(),
+                            venue_id: "2".to_string(),
+                        },
+                        CinemaVenue {
+                            chain_id: "cinema-city".to_string(),
+                            venue_name: "Wroclaw - Wroclavia".to_string(),
+                            venue_id: "3".to_string(),
+                        },
+                    ],
+                ),
+            ),
+            registered_chain(
+                CinemaChainId::Helios,
+                "Helios",
+                FakeCinemaClient::new(
+                    Vec::new(),
+                    vec![CinemaVenue {
+                        chain_id: "helios".to_string(),
+                        venue_name: "Łódź - Helios".to_string(),
+                        venue_id: "lodz/kino-helios".to_string(),
+                    }],
+                ),
+            ),
+        ],
+        FakeTmdbService { result: Default::default(), error: None },
+    );
+    let mut configured_settings = settings();
+    configured_settings
+        .user_preferences
+        .default_venues
+        .set(CinemaChainId::Helios, Some("Łódź - Helios".to_string()));
+    write_settings(&configured_settings, &dependencies.paths).unwrap();
+    assert!(!dependencies.paths.db_file().exists());
+    let mut terminal = BufferTerminal::default();
+
+    let exit_code = run_with_args(
+        vec!["quickrep".to_string(), "repertoire".to_string()],
+        &dependencies,
+        &mut terminal,
+    )
+    .await;
+
+    let output = terminal.into_string();
+    assert_eq!(exit_code, 0);
+    assert!(output.contains("Repertuar dla Cinema City"));
+    assert!(output.contains("Wroclaw - Wroclavia"));
+    assert!(output.contains("Test Movie"));
+    assert!(dependencies.paths.db_file().exists());
+    assert_eq!(
+        DatabaseManager::new(dependencies.paths.db_file())
+            .unwrap()
+            .get_all_venues("cinema-city")
+            .unwrap()
+            .into_iter()
+            .map(|venue| (venue.venue_name, venue.venue_id))
+            .collect::<Vec<_>>(),
+        vec![
+            ("Warszawa - Janki".to_string(), "2".to_string()),
+            ("Wroclaw - Wroclavia".to_string(), "3".to_string()),
+        ]
+    );
+    assert_eq!(
+        DatabaseManager::new(dependencies.paths.db_file())
+            .unwrap()
+            .get_all_venues("helios")
+            .unwrap()
+            .into_iter()
+            .map(|venue| (venue.venue_name, venue.venue_id))
+            .collect::<Vec<_>>(),
+        vec![("Łódź - Helios".to_string(), "lodz/kino-helios".to_string())]
+    );
+}
+
+#[tokio::test]
 async fn venues_commands_update_list_and_search_round_trip_through_database() {
     let temp_dir = tempdir().unwrap();
     let dependencies = dependencies(

--- a/tests/app_test.rs
+++ b/tests/app_test.rs
@@ -33,6 +33,7 @@ fn binary_help_lists_top_level_commands() {
         .stdout(predicates::str::contains("Użycie"))
         .stdout(predicates::str::contains("Polecenia"))
         .stdout(predicates::str::contains("Opcje"))
+        .stdout(predicates::str::contains("chains"))
         .stdout(predicates::str::contains("configure"))
         .stdout(predicates::str::contains("repertoire"))
         .stdout(predicates::str::contains("venues"));
@@ -64,6 +65,50 @@ async fn repertoire_command_exits_for_unsupported_chain() {
 
     assert_eq!(exit_code, 1);
     assert!(terminal.into_string().contains("Nieobsługiwana sieć kin"));
+}
+
+#[tokio::test]
+async fn chains_command_lists_supported_chains_without_configuration() {
+    let temp_dir = tempdir().unwrap();
+    let dependencies = dependencies_with_chains(
+        temp_dir.path(),
+        FakePrompt::new(Vec::new(), Vec::new()),
+        vec![
+            registered_chain(
+                CinemaChainId::CinemaCity,
+                "Cinema City",
+                FakeCinemaClient::new(Vec::new(), Vec::new()),
+            ),
+            registered_chain(
+                CinemaChainId::Helios,
+                "Helios",
+                FakeCinemaClient::new(Vec::new(), Vec::new()),
+            ),
+            registered_chain(
+                CinemaChainId::Multikino,
+                "Multikino",
+                FakeCinemaClient::new(Vec::new(), Vec::new()),
+            ),
+        ],
+        FakeTmdbService { result: Default::default(), error: None },
+    );
+    let mut terminal = BufferTerminal::default();
+
+    let exit_code = run_with_args(
+        vec!["quickrep".to_string(), "chains".to_string()],
+        &dependencies,
+        &mut terminal,
+    )
+    .await;
+
+    let output = terminal.into_string();
+    assert_eq!(exit_code, 0);
+    assert!(output.contains("Obsługiwane sieci kin"));
+    assert!(output.contains("Cinema City"));
+    assert!(output.contains("cinema-city"));
+    assert!(output.contains("Helios"));
+    assert!(output.contains("Multikino"));
+    assert!(!dependencies.paths.config_file().exists());
 }
 
 #[tokio::test]

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -326,6 +326,19 @@ async fn run_interactive_configuration_fetches_all_chain_venues_concurrently() {
                     tracker: tracker.clone(),
                 },
             ),
+            delayed_registered_chain(
+                CinemaChainId::Multikino,
+                "Multikino",
+                DelayedCinemaClient {
+                    venues: vec![CinemaVenue {
+                        chain_id: "multikino".to_string(),
+                        venue_name: "Warszawa Złote Tarasy".to_string(),
+                        venue_id: "0034".to_string(),
+                    }],
+                    delay: Duration::from_millis(75),
+                    tracker: tracker.clone(),
+                },
+            ),
         ],
         FakeTmdbService { result: Default::default(), error: None },
     );
@@ -339,7 +352,7 @@ async fn run_interactive_configuration_fetches_all_chain_venues_concurrently() {
     .await
     .unwrap();
 
-    assert_eq!(tracker.max_in_flight(), 2);
+    assert_eq!(tracker.max_in_flight(), 3);
     assert_eq!(
         configured_settings.get_default_venue(CinemaChainId::CinemaCity),
         Some("Wroclaw - Wroclavia")
@@ -353,6 +366,16 @@ async fn run_interactive_configuration_fetches_all_chain_venues_concurrently() {
             .map(|venue| (venue.venue_name, venue.venue_id))
             .collect::<Vec<_>>(),
         vec![("Łódź - Helios".to_string(), "lodz/kino-helios".to_string())]
+    );
+    assert_eq!(
+        DatabaseManager::new(dependencies.paths.db_file())
+            .unwrap()
+            .get_all_venues("multikino")
+            .unwrap()
+            .into_iter()
+            .map(|venue| (venue.venue_name, venue.venue_id))
+            .collect::<Vec<_>>(),
+        vec![("Warszawa Złote Tarasy".to_string(), "0034".to_string())]
     );
 }
 

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -29,6 +29,10 @@ fn load_settings_roundtrips_config_ini() {
         .user_preferences
         .default_venues
         .set(CinemaChainId::Helios, Some("Łódź - Helios".to_string()));
+    expected_settings
+        .user_preferences
+        .default_venues
+        .set(CinemaChainId::Multikino, Some("Warszawa Złote Tarasy".to_string()));
 
     write_settings(&expected_settings, &paths).unwrap();
     let loaded_settings = load_settings(&paths).unwrap();
@@ -82,6 +86,7 @@ tmdb_access_token = token\n\
 [default_venues]\n\
 cinema_city = Wroclaw - Wroclavia\n\
 helios = Łódź - Helios\n\
+multikino = Warszawa Złote Tarasy\n\
 ",
     )
     .unwrap();
@@ -94,6 +99,10 @@ helios = Łódź - Helios\n\
         Some("Wroclaw - Wroclavia")
     );
     assert_eq!(loaded_settings.get_default_venue(CinemaChainId::Helios), Some("Łódź - Helios"));
+    assert_eq!(
+        loaded_settings.get_default_venue(CinemaChainId::Multikino),
+        Some("Warszawa Złote Tarasy")
+    );
 }
 
 #[test]

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -129,6 +129,7 @@ fn bootstrap_rules_match_help_and_configure_flows() {
         "--help".to_string()
     ]));
     assert!(should_defer_bootstrap_to_command(&["configure".to_string()]));
+    assert!(should_defer_bootstrap_to_command(&["chains".to_string()]));
     assert!(!should_defer_bootstrap_to_command(&["repertoire".to_string()]));
 }
 

--- a/tests/multikino_test.rs
+++ b/tests/multikino_test.rs
@@ -1,0 +1,299 @@
+use httpmock::Method::GET;
+use httpmock::MockServer;
+use quick_repertoire::cinema::multikino::Multikino;
+use quick_repertoire::cinema::registry::CinemaChainClient;
+use quick_repertoire::domain::CinemaVenue;
+use serde_json::json;
+
+fn build_client(server: &MockServer) -> Multikino {
+    Multikino::new(server.base_url())
+        .with_showings_api_base_url(format!("{}/api/microservice/showings", server.base_url()))
+}
+
+#[tokio::test]
+async fn fetch_venues_parses_multikino_api_response() {
+    let server = MockServer::start();
+    let venues_mock = server.mock(|when, then| {
+        when.method(GET).path("/api/microservice/showings/cinemas");
+        then.status(200).json_body(json!({
+            "result": [
+                {
+                    "alpha": "W",
+                    "cinemas": [
+                        {
+                            "cinemaId": "0034",
+                            "cinemaName": "Warszawa Złote Tarasy",
+                            "fullName": "Warszawa Złote Tarasy"
+                        },
+                        {
+                            "cinemaId": "0052",
+                            "cinemaName": "Wrocław Pasaż Grunwaldzki",
+                            "fullName": "Wrocław Pasaż Grunwaldzki"
+                        }
+                    ]
+                },
+                {
+                    "alpha": "Ł",
+                    "cinemas": [
+                        {
+                            "cinemaId": "0010",
+                            "cinemaName": "Łódź",
+                            "fullName": "Łódź"
+                        }
+                    ]
+                }
+            ],
+            "responseCode": 0,
+            "errorMessage": null
+        }));
+    });
+
+    let client = build_client(&server);
+
+    let venues = client.fetch_venues().await.unwrap();
+
+    venues_mock.assert();
+    let mut actual = venues
+        .into_iter()
+        .map(|venue| (venue.chain_id, venue.venue_id, venue.venue_name))
+        .collect::<Vec<_>>();
+    actual.sort_by(|left, right| left.1.cmp(&right.1));
+
+    assert_eq!(
+        actual,
+        vec![
+            ("multikino".to_string(), "0010".to_string(), "Łódź".to_string(),),
+            ("multikino".to_string(), "0034".to_string(), "Warszawa Złote Tarasy".to_string(),),
+            ("multikino".to_string(), "0052".to_string(), "Wrocław Pasaż Grunwaldzki".to_string(),),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn fetch_repertoire_groups_multikino_sessions_by_format_and_language() {
+    let server = MockServer::start();
+    let films_mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/api/microservice/showings/cinemas/0034/films")
+            .query_param("minEmbargoLevel", "3")
+            .query_param("includesSession", "true")
+            .query_param("includeSessionAttributes", "true");
+        then.status(200).json_body(json!({
+            "result": [
+                {
+                    "filmId": "HO00002328",
+                    "filmUrl": format!("{}/filmy/projekt-hail-mary", server.base_url()),
+                    "filmTitle": "Projekt Hail Mary",
+                    "originalTitle": "Project Hail Mary",
+                    "releaseDate": "2026-03-20T00:00:00",
+                    "runningTime": 157,
+                    "isDurationUnknown": false,
+                    "genres": ["science fiction", "thriller"],
+                    "showingGroups": [
+                        {
+                            "date": "2026-04-03T00:00:00",
+                            "sessions": [
+                                {
+                                    "bookingUrl": "/rezerwacja-biletow/podsumowanie/0034/HO00002328/64811",
+                                    "startTime": "2026-04-03T18:30:00",
+                                    "isSoldOut": false,
+                                    "isBookingAvailable": true,
+                                    "attributes": [
+                                        {"name": "NAPISY", "attributeType": "Language"},
+                                        {"name": "2D", "attributeType": "Session"},
+                                        {"name": "Single Seat", "attributeType": "Session"}
+                                    ]
+                                },
+                                {
+                                    "bookingUrl": "/rezerwacja-biletow/podsumowanie/0034/HO00002328/64812",
+                                    "startTime": "2026-04-03T20:00:00",
+                                    "isSoldOut": false,
+                                    "isBookingAvailable": true,
+                                    "attributes": [
+                                        {"name": "NAPISY", "attributeType": "Language"},
+                                        {"name": "2D", "attributeType": "Session"},
+                                        {"name": "SUPERHIT", "attributeType": "Session"}
+                                    ]
+                                },
+                                {
+                                    "bookingUrl": "/rezerwacja-biletow/podsumowanie/0034/HO00002328/64813",
+                                    "startTime": "2026-04-03T21:15:00",
+                                    "isSoldOut": false,
+                                    "isBookingAvailable": true,
+                                    "attributes": [
+                                        {"name": "DUBBING", "attributeType": "Language"},
+                                        {"name": "2D", "attributeType": "Session"}
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "date": "2026-04-04T00:00:00",
+                            "sessions": [
+                                {
+                                    "bookingUrl": "/rezerwacja-biletow/podsumowanie/0034/HO00002328/64814",
+                                    "startTime": "2026-04-04T10:30:00",
+                                    "isSoldOut": false,
+                                    "isBookingAvailable": true,
+                                    "attributes": [
+                                        {"name": "NAPISY", "attributeType": "Language"},
+                                        {"name": "2D", "attributeType": "Session"}
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "filmId": "HO00002255",
+                    "filmUrl": format!(
+                        "{}/filmy/rbo-sezon-kinowy-2025-26-czarodziejski-flet",
+                        server.base_url()
+                    ),
+                    "filmTitle": "Royal Ballet and Opera Sezon Kinowy 2025-26: Czarodziejski flet",
+                    "originalTitle": "RBO Cinema Season 2025-26: The Magic Flute",
+                    "releaseDate": "2026-04-26T00:00:00",
+                    "runningTime": 210,
+                    "isDurationUnknown": false,
+                    "genres": ["opera"],
+                    "showingGroups": [
+                        {
+                            "date": "2026-04-03T00:00:00",
+                            "sessions": [
+                                {
+                                    "bookingUrl": "/rezerwacja-biletow/podsumowanie/0034/HO00002255/46519",
+                                    "startTime": "2026-04-03T15:00:00",
+                                    "isSoldOut": false,
+                                    "isBookingAvailable": true,
+                                    "attributes": [
+                                        {"name": "NAPISY", "attributeType": "Language"},
+                                        {"name": "2D", "attributeType": "Session"},
+                                        {"name": "KULTOWE KINO", "attributeType": "Session"},
+                                        {"name": "OPERA", "attributeType": "Movie"}
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "filmId": "HO00009999",
+                    "filmUrl": format!("{}/filmy/inna-data", server.base_url()),
+                    "filmTitle": "Inna data",
+                    "runningTime": 101,
+                    "isDurationUnknown": false,
+                    "genres": ["dramat"],
+                    "showingGroups": [
+                        {
+                            "date": "2026-04-07T00:00:00",
+                            "sessions": [
+                                {
+                                    "bookingUrl": "/rezerwacja-biletow/podsumowanie/0034/HO00009999/99999",
+                                    "startTime": "2026-04-07T19:00:00",
+                                    "isSoldOut": false,
+                                    "isBookingAvailable": true,
+                                    "attributes": [
+                                        {"name": "NAPISY", "attributeType": "Language"},
+                                        {"name": "2D", "attributeType": "Session"}
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "responseCode": 0,
+            "errorMessage": null
+        }));
+    });
+    let attribute_groups_mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/api/microservice/showings/attributes/showingAttributeGroups")
+            .query_param("cinemaId", "0034")
+            .query_param("minEmbargoLevel", "2");
+        then.status(200).json_body(json!({
+            "result": [
+                {
+                    "name": "Rodzaj pokazu",
+                    "showingAttributes": [
+                        {"name": "2D", "attributeType": "Session"},
+                        {"name": "KULTOWE KINO", "attributeType": "Session"}
+                    ]
+                },
+                {
+                    "name": "Wersja językowa",
+                    "showingAttributes": [
+                        {"name": "DUBBING", "attributeType": "Language"},
+                        {"name": "NAPISY", "attributeType": "Language"},
+                        {"name": "POLSKI", "attributeType": "Language"}
+                    ]
+                }
+            ],
+            "responseCode": 0,
+            "errorMessage": null
+        }));
+    });
+
+    let client = build_client(&server);
+    let venue = CinemaVenue {
+        chain_id: "multikino".to_string(),
+        venue_id: "0034".to_string(),
+        venue_name: "Warszawa Złote Tarasy".to_string(),
+    };
+
+    let repertoire = client.fetch_repertoire("2026-04-03", &venue).await.unwrap();
+
+    films_mock.assert();
+    attribute_groups_mock.assert();
+    assert_eq!(repertoire.len(), 2);
+
+    let hail_mary_page_url = format!("{}/filmy/projekt-hail-mary", server.base_url());
+    let hail_mary_first_booking =
+        format!("{}/rezerwacja-biletow/podsumowanie/0034/HO00002328/64811", server.base_url());
+    let hail_mary_second_booking =
+        format!("{}/rezerwacja-biletow/podsumowanie/0034/HO00002328/64812", server.base_url());
+
+    let hail_mary = &repertoire[0];
+    assert_eq!(hail_mary.title, "Projekt Hail Mary");
+    assert_eq!(hail_mary.genres, "science fiction, thriller");
+    assert_eq!(hail_mary.play_length, "157 min");
+    assert_eq!(hail_mary.original_language, "Brak danych");
+    assert_eq!(hail_mary.lookup_metadata.chain_movie_id.as_deref(), Some("HO00002328"));
+    assert_eq!(
+        hail_mary.lookup_metadata.movie_page_url.as_deref(),
+        Some(hail_mary_page_url.as_str())
+    );
+    assert_eq!(hail_mary.lookup_metadata.alternate_titles, vec!["Project Hail Mary".to_string()]);
+    assert_eq!(hail_mary.lookup_metadata.runtime_minutes, Some(157));
+    assert_eq!(hail_mary.lookup_metadata.polish_premiere_date.as_deref(), Some("2026-03-20"));
+    assert_eq!(hail_mary.lookup_metadata.production_year, Some(2026));
+    assert_eq!(hail_mary.lookup_metadata.genre_tags, vec!["science fiction", "thriller"]);
+    assert_eq!(hail_mary.play_details.len(), 2);
+    assert_eq!(hail_mary.play_details[0].format, "2D");
+    assert_eq!(hail_mary.play_details[0].play_language, "NAPISY");
+    assert_eq!(
+        hail_mary.play_details[0]
+            .play_times
+            .iter()
+            .map(|play_time| (play_time.value.as_str(), play_time.url.as_deref()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("18:30", Some(hail_mary_first_booking.as_str())),
+            ("20:00", Some(hail_mary_second_booking.as_str())),
+        ]
+    );
+    assert_eq!(hail_mary.play_details[1].format, "2D");
+    assert_eq!(hail_mary.play_details[1].play_language, "DUBBING");
+    assert_eq!(hail_mary.play_details[1].play_times[0].value, "21:15");
+
+    let magic_flute = &repertoire[1];
+    assert_eq!(
+        magic_flute.title,
+        "Royal Ballet and Opera Sezon Kinowy 2025-26: Czarodziejski flet"
+    );
+    assert_eq!(magic_flute.genres, "opera");
+    assert_eq!(magic_flute.play_details.len(), 1);
+    assert_eq!(magic_flute.play_details[0].format, "2D KULTOWE KINO");
+    assert_eq!(magic_flute.play_details[0].play_language, "NAPISY");
+    assert_eq!(magic_flute.play_details[0].play_times[0].value, "15:00");
+}

--- a/tests/multikino_test.rs
+++ b/tests/multikino_test.rs
@@ -1,13 +1,78 @@
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
 use httpmock::Method::GET;
 use httpmock::MockServer;
 use quick_repertoire::cinema::multikino::Multikino;
 use quick_repertoire::cinema::registry::CinemaChainClient;
 use quick_repertoire::domain::CinemaVenue;
+use quick_repertoire::retry::RetryPolicy;
 use serde_json::json;
 
 fn build_client(server: &MockServer) -> Multikino {
     Multikino::new(server.base_url())
         .with_showings_api_base_url(format!("{}/api/microservice/showings", server.base_url()))
+}
+
+fn json_response(
+    status_code: u16,
+    reason_phrase: &str,
+    body: serde_json::Value,
+    extra_headers: &[(&str, &str)],
+) -> String {
+    let body = body.to_string();
+    let mut response = format!(
+        "HTTP/1.1 {status_code} {reason_phrase}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n",
+        body.len()
+    );
+
+    for (name, value) in extra_headers {
+        response.push_str(&format!("{name}: {value}\r\n"));
+    }
+
+    response.push_str("\r\n");
+    response.push_str(&body);
+    response
+}
+
+fn start_sequenced_http_server(
+    responses: Vec<String>,
+) -> (String, Arc<Mutex<Vec<String>>>, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("test server should bind");
+    let address = listener.local_addr().expect("test server should expose its address");
+    let recorded_requests = Arc::new(Mutex::new(Vec::new()));
+    let recorded_requests_handle = recorded_requests.clone();
+
+    let server = thread::spawn(move || {
+        for response in responses {
+            let (mut stream, _) = listener.accept().expect("test server should accept a request");
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 1024];
+
+            loop {
+                let bytes_read = stream.read(&mut buffer).expect("request should be readable");
+                if bytes_read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..bytes_read]);
+                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+
+            recorded_requests_handle
+                .lock()
+                .expect("recorded requests lock poisoned")
+                .push(String::from_utf8_lossy(&request).into_owned());
+            stream.write_all(response.as_bytes()).expect("response should be writable");
+            stream.flush().expect("response should be flushed");
+        }
+    });
+
+    (format!("http://{address}"), recorded_requests, server)
 }
 
 #[tokio::test]
@@ -67,6 +132,113 @@ async fn fetch_venues_parses_multikino_api_response() {
             ("multikino".to_string(), "0052".to_string(), "Wrocław Pasaż Grunwaldzki".to_string(),),
         ]
     );
+}
+
+#[tokio::test]
+async fn fetch_venues_trims_ids_and_deduplicates_whitespace_variants() {
+    let server = MockServer::start();
+    let venues_mock = server.mock(|when, then| {
+        when.method(GET).path("/api/microservice/showings/cinemas");
+        then.status(200).json_body(json!({
+            "result": [
+                {
+                    "alpha": "W",
+                    "cinemas": [
+                        {
+                            "cinemaId": " 0034 ",
+                            "cinemaName": "Warszawa Złote Tarasy",
+                            "fullName": "  Warszawa Złote Tarasy  "
+                        },
+                        {
+                            "cinemaId": "0034",
+                            "cinemaName": "Warszawa duplicate",
+                            "fullName": "Warszawa duplicate"
+                        },
+                        {
+                            "cinemaId": " 0052",
+                            "cinemaName": "Wrocław Pasaż Grunwaldzki",
+                            "fullName": "Wrocław Pasaż Grunwaldzki"
+                        },
+                        {
+                            "cinemaId": "   ",
+                            "cinemaName": "Ignored",
+                            "fullName": "Ignored"
+                        }
+                    ]
+                }
+            ],
+            "responseCode": 0,
+            "errorMessage": null
+        }));
+    });
+
+    let client = build_client(&server);
+
+    let venues = client.fetch_venues().await.unwrap();
+
+    venues_mock.assert();
+    let mut actual =
+        venues.into_iter().map(|venue| (venue.venue_id, venue.venue_name)).collect::<Vec<_>>();
+    actual.sort_by(|left, right| left.0.cmp(&right.0));
+
+    assert_eq!(
+        actual,
+        vec![
+            ("0034".to_string(), "Warszawa Złote Tarasy".to_string()),
+            ("0052".to_string(), "Wrocław Pasaż Grunwaldzki".to_string()),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn fetch_venues_honors_retry_after_header_on_rate_limit() {
+    let (base_url, recorded_requests, server) = start_sequenced_http_server(vec![
+        json_response(
+            429,
+            "Too Many Requests",
+            json!({"message": "slow down"}),
+            &[("Retry-After", "0")],
+        ),
+        json_response(
+            200,
+            "OK",
+            json!({
+                "result": [
+                    {
+                        "alpha": "W",
+                        "cinemas": [
+                            {
+                                "cinemaId": "0034",
+                                "cinemaName": "Warszawa Złote Tarasy",
+                                "fullName": "Warszawa Złote Tarasy"
+                            }
+                        ]
+                    }
+                ],
+                "responseCode": 0,
+                "errorMessage": null
+            }),
+            &[],
+        ),
+    ]);
+
+    let client = Multikino::new(base_url.clone())
+        .with_showings_api_base_url(format!("{base_url}/api/microservice/showings"))
+        .with_retry_policy(RetryPolicy::new(2, Duration::from_secs(1), Duration::from_secs(1)));
+
+    let started_at = Instant::now();
+    let venues = client.fetch_venues().await.unwrap();
+    let elapsed = started_at.elapsed();
+
+    server.join().expect("test server should finish cleanly");
+
+    assert!(
+        elapsed < Duration::from_millis(500),
+        "expected Retry-After header to avoid generic backoff, elapsed was {elapsed:?}"
+    );
+    assert_eq!(recorded_requests.lock().expect("recorded requests lock poisoned").len(), 2);
+    assert_eq!(venues.len(), 1);
+    assert_eq!(venues[0].venue_id, "0034");
 }
 
 #[tokio::test]

--- a/tests/output_test.rs
+++ b/tests/output_test.rs
@@ -7,7 +7,8 @@ use quick_repertoire::domain::{
     RepertoireCliTableMetadata, TmdbMovieDetails,
 };
 use quick_repertoire::output::{
-    cinema_venue_input_parser, date_input_parser, render_repertoire_table, render_venues_table,
+    cinema_venue_input_parser, date_input_parser, render_chains_table, render_repertoire_table,
+    render_venues_table,
 };
 
 #[test]
@@ -69,6 +70,21 @@ fn render_venues_table_renders_table_for_found_venues() {
     assert!(rendered_output.contains("Nazwa lokalu"));
     assert!(rendered_output.contains("ID lokalu"));
     assert!(rendered_output.contains("Wroclaw - Wroclavia"));
+}
+
+#[test]
+fn render_chains_table_renders_supported_chains() {
+    let rendered_output = render_chains_table(&[
+        ("Cinema City".to_string(), "cinema-city".to_string()),
+        ("Helios".to_string(), "helios".to_string()),
+        ("Multikino".to_string(), "multikino".to_string()),
+    ]);
+
+    assert!(rendered_output.contains("Obsługiwane sieci kin"));
+    assert!(rendered_output.contains("Nazwa sieci"));
+    assert!(rendered_output.contains("ID sieci"));
+    assert!(rendered_output.contains("Cinema City"));
+    assert!(rendered_output.contains("multikino"));
 }
 
 #[test]

--- a/tests/tmdb_test.rs
+++ b/tests/tmdb_test.rs
@@ -903,7 +903,7 @@ async fn get_movie_ratings_and_summaries_accepts_legacy_v3_api_keys() {
         HashMap::from([(
             "Garfield".to_string(),
             TmdbMovieDetails {
-                rating: "6.717/10\n(głosy: 184)".to_string(),
+                rating: "6.7/10\n(głosy: 184)".to_string(),
                 summary: "Garfield jest najbardziej znanym kotem na świecie.".to_string(),
             }
         )])
@@ -980,7 +980,7 @@ async fn get_movie_ratings_and_summaries_retries_retryable_tmdb_responses() {
         HashMap::from([(
             "Garfield".to_string(),
             TmdbMovieDetails {
-                rating: "6.717/10\n(głosy: 184)".to_string(),
+                rating: "6.7/10\n(głosy: 184)".to_string(),
                 summary: "Garfield jest najbardziej znanym kotem na świecie.".to_string(),
             }
         )])


### PR DESCRIPTION
Add support for Multikino cinema chain, including API integration, venue fetching, repertoire parsing, and test coverage. Updated documentation and configuration to include Multikino alongside existing chains.